### PR TITLE
chore: remove importmap and bundle React

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,16 +28,6 @@
             font-family: 'Orbitron', sans-serif;
         }
     </style>
-<script type="importmap">
-{
-  "imports": {
-    "react": "https://esm.sh/react@^19.1.1",
-    "react-dom/": "https://esm.sh/react-dom@^19.1.1/",
-    "react/": "https://esm.sh/react@^19.1.1/",
-    "@google/genai": "https://esm.sh/@google/genai@^1.13.0"
-  }
-}
-</script>
 </head>
 <body class="bg-gray-900 text-gray-100">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- remove import map from `index.html` to use local packages instead of CDN
- let Vite resolve React packages during build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b8c395c1c8330a5236377fd578fac