### PR TITLE
feat: sync local storage across tabs

### DIFF
--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -30,5 +30,27 @@ export function useLocalStorage<T>(key: string, initialValue: T): [T, Dispatch<S
         }
     }, [key, value]);
 
+    useEffect(() => {
+        const handleStorage = (event: StorageEvent) => {
+            if (event.key !== key) {
+                return;
+            }
+            if (event.newValue) {
+                try {
+                    setValue(JSON.parse(event.newValue));
+                } catch (e) {
+                    console.error("Failed to parse localStorage value", e);
+                }
+            } else {
+                setValue(initialValue);
+            }
+        };
+
+        window.addEventListener('storage', handleStorage);
+        return () => {
+            window.removeEventListener('storage', handleStorage);
+        };
+    }, [key, initialValue]);
+
     return [value, setValue];
 }


### PR DESCRIPTION
## Summary
- update useLocalStorage to listen for `storage` events and update state across tabs
- remove event listener on cleanup

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b907fdc448330982ef6e46ee396c4