### PR TITLE
Clone time block state in modal to prevent external mutation

### DIFF
--- a/components/ScheduleManager.tsx
+++ b/components/ScheduleManager.tsx
@@ -39,7 +39,7 @@ const TimeBlockModal: React.FC<{
     onClose: () => void;
     onDelete?: (id: string) => void;
 }> = ({ block, onSave, onClose, onDelete }) => {
-    const [editedBlock, setEditedBlock] = useState(block);
+    const [editedBlock, setEditedBlock] = useState(() => structuredClone(block));
     const isEditing = 'id' in block;
 
     const handleSubmit = (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- Clone the provided time block when initializing modal state to avoid unintended mutations of the original object

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b907dfe68833088621e47d4229bf7