### PR TITLE
Refactor breathing exercise phase transition

### DIFF
--- a/components/BreathingExercise.tsx
+++ b/components/BreathingExercise.tsx
@@ -30,24 +30,22 @@ const BreathingExercise: React.FC<BreathingExerciseProps> = ({ quest, onComplete
                 if (prev > 1) {
                     return prev - 1;
                 }
-                
+
                 // Move to next phase
-                setPhaseIndex(currentPhaseIndex => {
-                    const nextPhaseIndex = (currentPhaseIndex + 1) % PHASES.length;
-                    if(nextPhaseIndex === 0) {
-                        setReps(currentReps => {
-                            if(currentReps + 1 >= TOTAL_REPS) {
-                                setIsFinished(true);
-                                clearInterval(timer);
-                                return currentReps + 1;
-                            }
-                            return currentReps + 1;
-                        });
-                    }
-                    setCountdown(PHASES[nextPhaseIndex].duration);
-                    return nextPhaseIndex;
-                });
-                return PHASES[(phaseIndex + 1) % PHASES.length].duration;
+                const nextPhaseIndex = (phaseIndex + 1) % PHASES.length;
+                setPhaseIndex(nextPhaseIndex);
+
+                if (nextPhaseIndex === 0) {
+                    setReps(currentReps => {
+                        if (currentReps + 1 >= TOTAL_REPS) {
+                            setIsFinished(true);
+                            clearInterval(timer);
+                        }
+                        return currentReps + 1;
+                    });
+                }
+
+                return PHASES[nextPhaseIndex].duration;
             });
         }, 1000);
 


### PR DESCRIPTION
## Summary
- Simplify breathing exercise timer logic by computing next phase index once and batching phaseIndex/countdown updates.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b9078dc848330aa1d618cf1de9427