### PR TITLE
Add Vite React plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@vitejs/plugin-react": "^4.3.1",
         "@types/node": "^22.14.0",
         "typescript": "^5.4.5",
         "vite": "^5.3.1"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@google/genai": "^1.13.0"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
     "@types/node": "^22.14.0",
     "typescript": "^5.4.5",
     "vite": "^5.3.1"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,11 @@
 import path from 'path';
+import react from '@vitejs/plugin-react';
 import { defineConfig, loadEnv } from 'vite';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      plugins: [react()],
       define: {
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },


### PR DESCRIPTION
## Summary
- add `@vitejs/plugin-react` as a dev dependency
- configure Vite to load the React plugin

## Testing
- `npm install --save-dev @vitejs/plugin-react --registry=https://registry.npmjs.org` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b907ed3e48330b2b1d787081a2244