### PR TITLE
feat: proxy Gemini requests through server

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ View your app in AI Studio: https://ai.studio/apps/drive/1nQM3LLeJ69WzOlhiaJQP2D
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set the `GEMINI_API_KEY` environment variable (e.g., in an `.env` file) with your Gemini API key. It is used only on the server and is not exposed to the client.
 3. Run the app:
    `npm run dev`

--- a/server/api/gemini.ts
+++ b/server/api/gemini.ts
@@ -1,0 +1,171 @@
+import { GoogleGenAI, Type } from '@google/genai';
+import type { Goal, Habit } from '../../types';
+
+const apiKey = process.env.GEMINI_API_KEY;
+
+if (!apiKey) {
+  console.warn('GEMINI_API_KEY environment variable not set. Gemini features will be disabled.');
+}
+
+const ai = apiKey ? new GoogleGenAI({ apiKey }) : null;
+
+const habitSchema = {
+  type: Type.OBJECT,
+  properties: {
+    name: {
+      type: Type.STRING,
+      description: "A short, actionable name for the habit (e.g., 'Meditate for 10 minutes').",
+    },
+    description: {
+      type: Type.STRING,
+      description: 'A brief explanation of why this habit is beneficial for the user\'s goals.',
+    },
+  },
+  required: ['name', 'description'],
+};
+
+const questSchema = {
+  type: Type.OBJECT,
+  properties: {
+    title: {
+      type: Type.STRING,
+      description: "A short, engaging title for the quest (e.g., 'The 5-Minute Mind Reset').",
+    },
+    description: {
+      type: Type.STRING,
+      description: 'A brief, motivating description of the quest and its purpose.',
+    },
+    reward: {
+      type: Type.INTEGER,
+      description: 'An appropriate SP reward value for completing the quest, usually between 20 and 100.',
+    },
+    type: {
+      type: Type.STRING,
+      description: "The type of quest. Must be 'generic'.",
+      enum: ['generic'],
+    },
+  },
+  required: ['title', 'description', 'reward', 'type'],
+};
+
+export default async function handler(req: any, res: any) {
+  if (req.method && req.method !== 'POST') {
+    res.status?.(405).json?.({ error: 'Method not allowed' });
+    return;
+  }
+
+  if (!ai) {
+    res.status?.(500).json?.({ error: 'Gemini API key is not configured.' });
+    return;
+  }
+
+  const body = req.body || (await getRequestBody(req));
+  const { type, goals, habits } = body as {
+    type: 'habits' | 'quests';
+    goals: Goal[];
+    habits?: Habit[];
+  };
+
+  try {
+    if (type === 'habits') {
+      const goalDescriptions = goals.map((g) => `- ${g.name}: ${g.description}`).join('\n');
+      const prompt = `
+Based on the following long-term goals, suggest 3-5 new daily or weekly habits that would help achieve them.
+The habits should be specific, actionable, and small enough to be incorporated into a daily routine.
+Avoid suggesting habits the user might already be doing. Focus on creative or supportive habits.
+
+My Goals:
+${goalDescriptions}
+
+Provide the habits in the specified JSON format.
+`;
+
+      const response = await ai.models.generateContent({
+        model: 'gemini-2.5-flash',
+        contents: prompt,
+        config: {
+          responseMimeType: 'application/json',
+          responseSchema: {
+            type: Type.OBJECT,
+            properties: {
+              habits: {
+                type: Type.ARRAY,
+                items: habitSchema,
+              },
+            },
+            required: ['habits'],
+          },
+        },
+      });
+
+      const jsonText = response.text.trim();
+      const result = JSON.parse(jsonText);
+      res.status?.(200).json?.({ habits: result?.habits || [] });
+      return;
+    }
+
+    if (type === 'quests') {
+      const goalDescriptions = goals.map((g) => `- ${g.name}`).join('\n');
+      const habitDescriptions = (habits || []).map((h) => `- ${h.name}`).join('\n');
+      const prompt = `
+Based on the following long-term goals and daily habits, suggest 2-3 unique, one-time "quests".
+A quest should be a specific, short-term challenge that pushes the user slightly beyond their routine to accelerate progress.
+For example, if a goal is 'Learn a new skill', a quest could be 'Complete a 2-hour tutorial on the topic'.
+Avoid suggesting things that are already listed as habits.
+
+My Goals:
+${goalDescriptions}
+
+My Habits:
+${habitDescriptions}
+
+Provide the quests in the specified JSON format. The quest 'type' must be 'generic'.
+`;
+
+      const response = await ai.models.generateContent({
+        model: 'gemini-2.5-flash',
+        contents: prompt,
+        config: {
+          responseMimeType: 'application/json',
+          responseSchema: {
+            type: Type.OBJECT,
+            properties: {
+              quests: {
+                type: Type.ARRAY,
+                items: questSchema,
+              },
+            },
+            required: ['quests'],
+          },
+        },
+      });
+
+      const jsonText = response.text.trim();
+      const result = JSON.parse(jsonText);
+      res.status?.(200).json?.({ quests: result?.quests || [] });
+      return;
+    }
+
+    res.status?.(400).json?.({ error: 'Invalid request type' });
+  } catch (error: any) {
+    res.status?.(500).json?.({ error: 'Error fetching suggestions from Gemini', details: String(error) });
+  }
+}
+
+async function getRequestBody(req: any) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on?.('data', (chunk: string) => {
+      data += chunk;
+    });
+    req.on?.('end', () => {
+      try {
+        resolve(JSON.parse(data || '{}'));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on?.('error', reject);
+  });
+}
+

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,152 +1,43 @@
-import { GoogleGenAI, Type } from "@google/genai";
 import type { Goal, Habit, Quest } from '../types';
 
-if (!process.env.GEMINI_API_KEY) {
-    console.warn("GEMINI_API_KEY environment variable not set. Gemini features will be disabled.");
-}
-
-const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY! });
-
-const habitSchema = {
-    type: Type.OBJECT,
-    properties: {
-        name: {
-            type: Type.STRING,
-            description: "A short, actionable name for the habit (e.g., 'Meditate for 10 minutes').",
-        },
-        description: {
-            type: Type.STRING,
-            description: "A brief explanation of why this habit is beneficial for the user's goals.",
-        },
-    },
-    required: ["name", "description"],
-};
-
+/**
+ * Request habit suggestions from the backend Gemini proxy.
+ */
 export const suggestHabitsForGoals = async (goals: Goal[]): Promise<Partial<Habit>[]> => {
-    if (!process.env.GEMINI_API_KEY) {
-        console.error("Gemini API key is not configured.");
-        return [
-            { name: "Review Goals Daily", description: "Start each day by reviewing your main objectives." },
-            { name: "Plan Tomorrow Today", description: "End your workday by planning the next." },
-        ];
-    }
-
-    const goalDescriptions = goals.map(g => `- ${g.name}: ${g.description}`).join('\n');
-
-    const prompt = `
-Based on the following long-term goals, suggest 3-5 new daily or weekly habits that would help achieve them.
-The habits should be specific, actionable, and small enough to be incorporated into a daily routine.
-Avoid suggesting habits the user might already be doing. Focus on creative or supportive habits.
-
-My Goals:
-${goalDescriptions}
-
-Provide the habits in the specified JSON format.
-`;
-
-    try {
-        const response = await ai.models.generateContent({
-            model: "gemini-2.5-flash",
-            contents: prompt,
-            config: {
-                responseMimeType: "application/json",
-                responseSchema: {
-                    type: Type.OBJECT,
-                    properties: {
-                        habits: {
-                            type: Type.ARRAY,
-                            items: habitSchema,
-                        },
-                    },
-                    required: ['habits'],
-                },
-            },
-        });
-        
-        const jsonText = response.text.trim();
-        const result = JSON.parse(jsonText);
-        
-        return result?.habits || [];
-
-    } catch (error) {
-        console.error("Error fetching or parsing habit suggestions from Gemini:", error);
-        return [];
-    }
+  try {
+    const response = await fetch('/api/gemini', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'habits', goals }),
+    });
+    if (!response.ok) throw new Error(`Server responded with ${response.status}`);
+    const data = await response.json();
+    return data.habits || [];
+  } catch (error) {
+    console.error('Error fetching habit suggestions from server:', error);
+    return [];
+  }
 };
 
-const questSchema = {
-    type: Type.OBJECT,
-    properties: {
-        title: {
-            type: Type.STRING,
-            description: "A short, engaging title for the quest (e.g., 'The 5-Minute Mind Reset').",
-        },
-        description: {
-            type: Type.STRING,
-            description: "A brief, motivating description of the quest and its purpose.",
-        },
-        reward: {
-            type: Type.INTEGER,
-            description: "An appropriate SP reward value for completing the quest, usually between 20 and 100.",
-        },
-        type: {
-            type: Type.STRING,
-            description: "The type of quest. Must be 'generic'.",
-            enum: ['generic']
-        }
-    },
-    required: ["title", "description", "reward", "type"],
+/**
+ * Request quest suggestions from the backend Gemini proxy.
+ */
+export const suggestQuests = async (
+  goals: Goal[],
+  habits: Habit[],
+): Promise<Omit<Quest, 'id' | 'completed'>[]> => {
+  try {
+    const response = await fetch('/api/gemini', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'quests', goals, habits }),
+    });
+    if (!response.ok) throw new Error(`Server responded with ${response.status}`);
+    const data = await response.json();
+    return data.quests || [];
+  } catch (error) {
+    console.error('Error fetching quest suggestions from server:', error);
+    return [];
+  }
 };
 
-export const suggestQuests = async (goals: Goal[], habits: Habit[]): Promise<Omit<Quest, 'id' | 'completed'>[]> => {
-    if (!process.env.GEMINI_API_KEY) {
-        console.error("Gemini API key is not configured.");
-        return [];
-    }
-
-    const goalDescriptions = goals.map(g => `- ${g.name}`).join('\n');
-    const habitDescriptions = habits.map(h => `- ${h.name}`).join('\n');
-
-    const prompt = `
-Based on the following long-term goals and daily habits, suggest 2-3 unique, one-time "quests".
-A quest should be a specific, short-term challenge that pushes the user slightly beyond their routine to accelerate progress.
-For example, if a goal is 'Learn a new skill', a quest could be 'Complete a 2-hour tutorial on the topic'.
-Avoid suggesting things that are already listed as habits.
-
-My Goals:
-${goalDescriptions}
-
-My Habits:
-${habitDescriptions}
-
-Provide the quests in the specified JSON format. The quest 'type' must be 'generic'.
-`;
-    try {
-        const response = await ai.models.generateContent({
-            model: "gemini-2.5-flash",
-            contents: prompt,
-            config: {
-                responseMimeType: "application/json",
-                responseSchema: {
-                    type: Type.OBJECT,
-                    properties: {
-                        quests: {
-                            type: Type.ARRAY,
-                            items: questSchema,
-                        },
-                    },
-                    required: ['quests'],
-                },
-            },
-        });
-
-        const jsonText = response.text.trim();
-        const result = JSON.parse(jsonText);
-        
-        return result?.quests || [];
-
-    } catch (error) {
-        console.error("Error fetching or parsing quest suggestions from Gemini:", error);
-        return [];
-    }
-};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,30 +1,24 @@
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 
-export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
-    return {
-      define: {
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        'service-worker': path.resolve(__dirname, 'service-worker.js'),
       },
-      resolve: {
-        alias: {
-          '@': path.resolve(__dirname, '.'),
-        }
+      output: {
+        entryFileNames: (chunk) =>
+          chunk.name === 'service-worker'
+            ? '[name].js'
+            : 'assets/[name]-[hash].js',
       },
-      build: {
-        rollupOptions: {
-          input: {
-            main: path.resolve(__dirname, 'index.html'),
-            'service-worker': path.resolve(__dirname, 'service-worker.js'),
-          },
-          output: {
-            entryFileNames: (chunk) =>
-              chunk.name === 'service-worker'
-                ? '[name].js'
-                : 'assets/[name]-[hash].js',
-          },
-        },
-      },
-    };
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- add server-side Gemini proxy reading GEMINI_API_KEY
- route front-end Gemini calls through the proxy instead of using @google/genai directly
- remove client exposure of GEMINI_API_KEY and document server-side usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b907694588330bc8673242858bbba