### PR TITLE
feat: add explorer tab and improve navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -92,7 +92,7 @@ const App: React.FC = () => {
     const [isSuggestingHabits, setIsSuggestingHabits] = useState<boolean>(false);
     const [isSuggestingQuests, setIsSuggestingQuests] = useState<boolean>(false);
     const [activeQuestId, setActiveQuestId] = useState<string | null>(null);
-    const [activeTab, setActiveTab] = useState<'habits' | 'goals' | 'schedule' | 'quests'>('habits');
+    const [activeTab, setActiveTab] = useState<'habits' | 'goals' | 'schedule' | 'quests' | 'explorer'>('habits');
 
     // --- Experience & Leveling ---
     const addExperience = useCallback((xp: number) => {
@@ -448,9 +448,11 @@ const App: React.FC = () => {
             )}
             <Header sublimePoints={sublimePoints} />
             <main className="p-4 md:p-8 max-w-7xl mx-auto pb-24">
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
-                   <Dashboard avatar={avatar} />
-                </div>
+                {activeTab === 'explorer' && (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
+                        <Dashboard avatar={avatar} />
+                    </div>
+                )}
 
                 {activeTab === 'habits' && (
                     <section id="habits" className="mb-12">
@@ -526,11 +528,47 @@ const App: React.FC = () => {
                     </section>
                 )}
             </main>
-            <nav className="fixed bottom-0 left-0 right-0 bg-gray-800 border-t border-gray-700 text-gray-400 flex justify-around py-2">
-                <button onClick={() => setActiveTab('habits')} className={`flex-1 ${activeTab === 'habits' ? 'text-white' : ''}`}>Habits</button>
-                <button onClick={() => setActiveTab('goals')} className={`flex-1 ${activeTab === 'goals' ? 'text-white' : ''}`}>Goals</button>
-                <button onClick={() => setActiveTab('schedule')} className={`flex-1 ${activeTab === 'schedule' ? 'text-white' : ''}`}>Schedule</button>
-                <button onClick={() => setActiveTab('quests')} className={`flex-1 ${activeTab === 'quests' ? 'text-white' : ''}`}>Quests</button>
+            <nav className="fixed bottom-0 left-0 right-0 bg-gray-800 border-t border-gray-700 text-gray-400 flex justify-around py-3 text-sm">
+                <button
+                    onClick={() => setActiveTab('habits')}
+                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'habits' ? 'text-white' : ''}`}
+                    aria-label="Habits"
+                    aria-current={activeTab === 'habits' ? 'page' : undefined}
+                >
+                    Habits
+                </button>
+                <button
+                    onClick={() => setActiveTab('goals')}
+                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'goals' ? 'text-white' : ''}`}
+                    aria-label="Goals"
+                    aria-current={activeTab === 'goals' ? 'page' : undefined}
+                >
+                    Goals
+                </button>
+                <button
+                    onClick={() => setActiveTab('schedule')}
+                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'schedule' ? 'text-white' : ''}`}
+                    aria-label="Schedule"
+                    aria-current={activeTab === 'schedule' ? 'page' : undefined}
+                >
+                    Schedule
+                </button>
+                <button
+                    onClick={() => setActiveTab('quests')}
+                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'quests' ? 'text-white' : ''}`}
+                    aria-label="Quests"
+                    aria-current={activeTab === 'quests' ? 'page' : undefined}
+                >
+                    Quests
+                </button>
+                <button
+                    onClick={() => setActiveTab('explorer')}
+                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'explorer' ? 'text-white' : ''}`}
+                    aria-label="Explorer"
+                    aria-current={activeTab === 'explorer' ? 'page' : undefined}
+                >
+                    Explorer
+                </button>
             </nav>
         </div>
     );


### PR DESCRIPTION
## Summary
- add dedicated Explorer tab for avatar dashboard
- enhance bottom navigation buttons for accessibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b9b4ccfdc83308cadcd28cb122fcb