### PR TITLE
feat: customize suggestion audience

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -93,6 +93,7 @@ const App: React.FC = () => {
     const [isSuggestingQuests, setIsSuggestingQuests] = useState<boolean>(false);
     const [activeQuestId, setActiveQuestId] = useState<string | null>(null);
     const [activeTab, setActiveTab] = useState<'habits' | 'goals' | 'schedule' | 'quests' | 'explorer'>('habits');
+    const [suggestionTarget, setSuggestionTarget] = useState<string>('');
 
     // --- Experience & Leveling ---
     const addExperience = useCallback((xp: number) => {
@@ -346,7 +347,7 @@ const App: React.FC = () => {
     const handleSuggestHabits = async () => {
         setIsSuggestingHabits(true);
         try {
-            const suggested = await suggestHabitsForGoals(goals);
+            const suggested = await suggestHabitsForGoals(goals, suggestionTarget);
             const newHabits: Habit[] = suggested.map((s, index) => ({
                 id: `suggested-h-${Date.now()}-${index}`,
                 name: s.name || 'New Habit',
@@ -366,7 +367,7 @@ const App: React.FC = () => {
     const handleSuggestQuests = async () => {
         setIsSuggestingQuests(true);
         try {
-            const suggested = await suggestQuests(goals, habits);
+            const suggested = await suggestQuests(goals, habits, suggestionTarget);
             const newQuests: Quest[] = suggested.map((q, index) => ({
                 id: `q-${Date.now()}-${index}`,
                 ...q,
@@ -448,6 +449,16 @@ const App: React.FC = () => {
             )}
             <Header sublimePoints={sublimePoints} />
             <main className="p-4 md:p-8 max-w-7xl mx-auto pb-24">
+                <div className="mb-8">
+                    <label className="block text-sm font-medium text-gray-300 mb-1">Suggestions for</label>
+                    <input
+                        type="text"
+                        value={suggestionTarget}
+                        onChange={e => setSuggestionTarget(e.target.value)}
+                        placeholder="the user"
+                        className="w-full md:w-1/2 bg-gray-800 border border-gray-700 rounded-md py-2 px-3 text-white"
+                    />
+                </div>
                 {activeTab === 'explorer' && (
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
                         <Dashboard avatar={avatar} />

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -24,7 +24,7 @@ const habitSchema = {
     required: ["name", "description"],
 };
 
-export const suggestHabitsForGoals = async (goals: Goal[]): Promise<Partial<Habit>[]> => {
+export const suggestHabitsForGoals = async (goals: Goal[], audience?: string): Promise<Partial<Habit>[]> => {
     if (!process.env.GEMINI_API_KEY) {
         console.error("Gemini API key is not configured.");
         return [
@@ -34,13 +34,14 @@ export const suggestHabitsForGoals = async (goals: Goal[]): Promise<Partial<Habi
     }
 
     const goalDescriptions = goals.map(g => `- ${g.name}: ${g.description}`).join('\n');
+    const target = audience?.trim() || 'the user';
 
     const prompt = `
-Based on the following long-term goals, suggest 3-5 new daily or weekly habits that would help achieve them.
+Based on the following long-term goals, suggest 3-5 new daily or weekly habits that would help ${target} achieve them.
 The habits should be specific, actionable, and small enough to be incorporated into a daily routine.
-Avoid suggesting habits the user might already be doing. Focus on creative or supportive habits.
+Avoid suggesting habits they might already be doing. Focus on creative or supportive habits.
 
-My Goals:
+Goals:
 ${goalDescriptions}
 
 Provide the habits in the specified JSON format.
@@ -104,7 +105,7 @@ const questSchema = {
     required: ["title", "description", "reward", "type"],
 };
 
-export const suggestQuests = async (goals: Goal[], habits: Habit[]): Promise<Omit<Quest, 'id' | 'completed'>[]> => {
+export const suggestQuests = async (goals: Goal[], habits: Habit[], audience?: string): Promise<Omit<Quest, 'id' | 'completed'>[]> => {
     if (!process.env.GEMINI_API_KEY) {
         console.error("Gemini API key is not configured.");
         return [];
@@ -112,17 +113,18 @@ export const suggestQuests = async (goals: Goal[], habits: Habit[]): Promise<Omi
 
     const goalDescriptions = goals.map(g => `- ${g.name}`).join('\n');
     const habitDescriptions = habits.map(h => `- ${h.name}`).join('\n');
+    const target = audience?.trim() || 'the user';
 
     const prompt = `
-Based on the following long-term goals and daily habits, suggest 2-3 unique, one-time "quests".
-A quest should be a specific, short-term challenge that pushes the user slightly beyond their routine to accelerate progress.
+Based on the following long-term goals and daily habits, suggest 2-3 unique, one-time "quests" for ${target}.
+A quest should be a specific, short-term challenge that pushes them slightly beyond their routine to accelerate progress.
 For example, if a goal is 'Learn a new skill', a quest could be 'Complete a 2-hour tutorial on the topic'.
 Avoid suggesting things that are already listed as habits.
 
-My Goals:
+Goals:
 ${goalDescriptions}
 
-My Habits:
+Habits:
 ${habitDescriptions}
 
 Provide the quests in the specified JSON format. The quest 'type' must be 'generic'.


### PR DESCRIPTION
## Summary
- add input to describe who AI suggestions should target
- pass audience context to Gemini service for habits and quests

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b9eb1f6ac83309da10cfb07be4214