### PR TITLE
feat: make tab buttons easier to use

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -539,46 +539,51 @@ const App: React.FC = () => {
                     </section>
                 )}
             </main>
-            <nav className="fixed bottom-0 left-0 right-0 bg-gray-800 border-t border-gray-700 text-gray-400 flex justify-around py-3 text-sm">
+            <nav className="fixed bottom-0 left-0 right-0 bg-gray-800 border-t border-gray-700 text-gray-400 flex justify-around py-2">
                 <button
                     onClick={() => setActiveTab('habits')}
-                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'habits' ? 'text-white' : ''}`}
+                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'habits' ? 'text-white' : ''}`}
                     aria-label="Habits"
                     aria-current={activeTab === 'habits' ? 'page' : undefined}
                 >
-                    Habits
+                    <span className="text-xl" aria-hidden="true">📋</span>
+                    <span>Habits</span>
                 </button>
                 <button
                     onClick={() => setActiveTab('goals')}
-                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'goals' ? 'text-white' : ''}`}
+                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'goals' ? 'text-white' : ''}`}
                     aria-label="Goals"
                     aria-current={activeTab === 'goals' ? 'page' : undefined}
                 >
-                    Goals
+                    <span className="text-xl" aria-hidden="true">🎯</span>
+                    <span>Goals</span>
                 </button>
                 <button
                     onClick={() => setActiveTab('schedule')}
-                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'schedule' ? 'text-white' : ''}`}
+                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'schedule' ? 'text-white' : ''}`}
                     aria-label="Schedule"
                     aria-current={activeTab === 'schedule' ? 'page' : undefined}
                 >
-                    Schedule
+                    <span className="text-xl" aria-hidden="true">📅</span>
+                    <span>Schedule</span>
                 </button>
                 <button
                     onClick={() => setActiveTab('quests')}
-                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'quests' ? 'text-white' : ''}`}
+                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'quests' ? 'text-white' : ''}`}
                     aria-label="Quests"
                     aria-current={activeTab === 'quests' ? 'page' : undefined}
                 >
-                    Quests
+                    <span className="text-xl" aria-hidden="true">⚔️</span>
+                    <span>Quests</span>
                 </button>
                 <button
                     onClick={() => setActiveTab('explorer')}
-                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'explorer' ? 'text-white' : ''}`}
+                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'explorer' ? 'text-white' : ''}`}
                     aria-label="Explorer"
                     aria-current={activeTab === 'explorer' ? 'page' : undefined}
                 >
-                    Explorer
+                    <span className="text-xl" aria-hidden="true">🧭</span>
+                    <span>Explorer</span>
                 </button>
             </nav>
         </div>


### PR DESCRIPTION
## Summary
- add emoji icons and vertically stacked labels to each tab button
- enlarge tab button touch area for easier navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba449e3b88330917a9992ede66589