### PR TITLE
Add progress tab and remove explorer navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import type { Avatar, Goal, Habit, Milestone, TimeBlock, Quest } from './types';
 import Header from './components/Header';
-import Dashboard from './components/Dashboard';
+import Progress from './components/Progress';
 import HabitTracker from './components/HabitTracker';
 import GoalTracker from './components/GoalTracker';
 import ScheduleManager from './components/ScheduleManager';
@@ -92,7 +92,7 @@ const App: React.FC = () => {
     const [isSuggestingHabits, setIsSuggestingHabits] = useState<boolean>(false);
     const [isSuggestingQuests, setIsSuggestingQuests] = useState<boolean>(false);
     const [activeQuestId, setActiveQuestId] = useState<string | null>(null);
-    const [activeTab, setActiveTab] = useState<'habits' | 'goals' | 'schedule' | 'quests' | 'explorer'>('habits');
+    const [activeTab, setActiveTab] = useState<'habits' | 'goals' | 'schedule' | 'quests' | 'progress'>('habits');
     const [suggestionTarget, setSuggestionTarget] = useState<string>('');
 
     // --- Experience & Leveling ---
@@ -459,9 +459,9 @@ const App: React.FC = () => {
                         className="w-full md:w-1/2 bg-gray-800 border border-gray-700 rounded-md py-2 px-3 text-white"
                     />
                 </div>
-                {activeTab === 'explorer' && (
+                {activeTab === 'progress' && (
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
-                        <Dashboard avatar={avatar} />
+                        <Progress avatar={avatar} />
                     </div>
                 )}
 
@@ -577,13 +577,13 @@ const App: React.FC = () => {
                     <span>Quests</span>
                 </button>
                 <button
-                    onClick={() => setActiveTab('explorer')}
-                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'explorer' ? 'text-white' : ''}`}
-                    aria-label="Explorer"
-                    aria-current={activeTab === 'explorer' ? 'page' : undefined}
+                    onClick={() => setActiveTab('progress')}
+                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'progress' ? 'text-white' : ''}`}
+                    aria-label="Progress"
+                    aria-current={activeTab === 'progress' ? 'page' : undefined}
                 >
-                    <span className="text-xl" aria-hidden="true">🧭</span>
-                    <span>Explorer</span>
+                    <span className="text-xl" aria-hidden="true">📈</span>
+                    <span>Progress</span>
                 </button>
             </nav>
         </div>

--- a/components/Progress.tsx
+++ b/components/Progress.tsx
@@ -3,11 +3,11 @@ import type { Avatar } from '../types';
 import QuestCard from './QuestCard';
 import { StarIcon } from './IconComponents';
 
-interface DashboardProps {
+interface ProgressProps {
     avatar: Avatar;
 }
 
-const Dashboard: React.FC<DashboardProps> = ({ avatar }) => {
+const Progress: React.FC<ProgressProps> = ({ avatar }) => {
     const progressPercentage = (avatar.currentXP / avatar.xpToNextLevel) * 100;
 
     return (
@@ -24,10 +24,10 @@ const Dashboard: React.FC<DashboardProps> = ({ avatar }) => {
                     </div>
                 </div>
                 <div className="flex-grow w-full text-center md:text-left">
-                    <h2 className="font-orbitron text-xl md:text-2xl text-white mb-2">Explorer Level {avatar.level}</h2>
+                    <h2 className="font-orbitron text-xl md:text-2xl text-white mb-2">Level {avatar.level}</h2>
                     <p className="text-gray-400 mb-4 text-sm md:text-base">Your journey to the sublime continues. Keep up the momentum!</p>
                     <div className="w-full bg-gray-700 rounded-full h-4 overflow-hidden border border-gray-600">
-                        <div 
+                        <div
                             className="bg-gradient-to-r from-cyan-400 to-blue-500 h-full rounded-full transition-all duration-500"
                             style={{ width: `${progressPercentage}%` }}
                         ></div>
@@ -42,4 +42,4 @@ const Dashboard: React.FC<DashboardProps> = ({ avatar }) => {
     );
 };
 
-export default Dashboard;
+export default Progress;


### PR DESCRIPTION
## Summary
- Introduce new Progress component to centralize level and XP display
- Replace Explorer home button with Progress tab in bottom navigation
- Update app state and routing to include `progress` tab

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba66733d4833088c5056e6d95273e