### PR TITLE
feat: customize suggestion audience

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -92,7 +92,8 @@ const App: React.FC = () => {
     const [isSuggestingHabits, setIsSuggestingHabits] = useState<boolean>(false);
     const [isSuggestingQuests, setIsSuggestingQuests] = useState<boolean>(false);
     const [activeQuestId, setActiveQuestId] = useState<string | null>(null);
-    const [activeTab, setActiveTab] = useState<'habits' | 'goals' | 'schedule' | 'quests' | 'explorer'>('habits');
+    const [activeTab, setActiveTab] = useState<'habits' | 'goals' | 'schedule' | 'quests' | 'progress'>('progress');
+    const [audience, setAudience] = useState<string>('');
 
     // --- Experience & Leveling ---
     const addExperience = useCallback((xp: number) => {
@@ -346,7 +347,7 @@ const App: React.FC = () => {
     const handleSuggestHabits = async () => {
         setIsSuggestingHabits(true);
         try {
-            const suggested = await suggestHabitsForGoals(goals);
+            const suggested = await suggestHabitsForGoals(goals, audience);
             const newHabits: Habit[] = suggested.map((s, index) => ({
                 id: `suggested-h-${Date.now()}-${index}`,
                 name: s.name || 'New Habit',
@@ -366,7 +367,7 @@ const App: React.FC = () => {
     const handleSuggestQuests = async () => {
         setIsSuggestingQuests(true);
         try {
-            const suggested = await suggestQuests(goals, habits);
+            const suggested = await suggestQuests(goals, habits, audience);
             const newQuests: Quest[] = suggested.map((q, index) => ({
                 id: `q-${Date.now()}-${index}`,
                 ...q,
@@ -448,10 +449,22 @@ const App: React.FC = () => {
             )}
             <Header sublimePoints={sublimePoints} />
             <main className="p-4 md:p-8 max-w-7xl mx-auto pb-24">
-                {activeTab === 'explorer' && (
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
-                        <Dashboard avatar={avatar} />
-                    </div>
+                {activeTab === 'progress' && (
+                    <>
+                        <div className="mb-8">
+                            <label className="block text-sm font-medium text-gray-300 mb-1">Suggestions for</label>
+                            <input
+                                type="text"
+                                value={audience}
+                                onChange={e => setAudience(e.target.value)}
+                                placeholder="the user"
+                                className="w-full md:w-1/2 bg-gray-800 border border-gray-700 rounded-md py-2 px-3 text-white"
+                            />
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
+                            <Dashboard avatar={avatar} />
+                        </div>
+                    </>
                 )}
 
                 {activeTab === 'habits' && (
@@ -530,6 +543,14 @@ const App: React.FC = () => {
             </main>
             <nav className="fixed bottom-0 left-0 right-0 bg-gray-800 border-t border-gray-700 text-gray-400 flex justify-around py-3 text-sm">
                 <button
+                    onClick={() => setActiveTab('progress')}
+                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'progress' ? 'text-white' : ''}`}
+                    aria-label="Progress"
+                    aria-current={activeTab === 'progress' ? 'page' : undefined}
+                >
+                    Progress
+                </button>
+                <button
                     onClick={() => setActiveTab('habits')}
                     className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'habits' ? 'text-white' : ''}`}
                     aria-label="Habits"
@@ -560,14 +581,6 @@ const App: React.FC = () => {
                     aria-current={activeTab === 'quests' ? 'page' : undefined}
                 >
                     Quests
-                </button>
-                <button
-                    onClick={() => setActiveTab('explorer')}
-                    className={`flex-1 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'explorer' ? 'text-white' : ''}`}
-                    aria-label="Explorer"
-                    aria-current={activeTab === 'explorer' ? 'page' : undefined}
-                >
-                    Explorer
                 </button>
             </nav>
         </div>

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -24,7 +24,7 @@ const Dashboard: React.FC<DashboardProps> = ({ avatar }) => {
                     </div>
                 </div>
                 <div className="flex-grow w-full text-center md:text-left">
-                    <h2 className="font-orbitron text-xl md:text-2xl text-white mb-2">Explorer Level {avatar.level}</h2>
+                    <h2 className="font-orbitron text-xl md:text-2xl text-white mb-2">Progress Level {avatar.level}</h2>
                     <p className="text-gray-400 mb-4 text-sm md:text-base">Your journey to the sublime continues. Keep up the momentum!</p>
                     <div className="w-full bg-gray-700 rounded-full h-4 overflow-hidden border border-gray-600">
                         <div 

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -24,7 +24,7 @@ const habitSchema = {
     required: ["name", "description"],
 };
 
-export const suggestHabitsForGoals = async (goals: Goal[]): Promise<Partial<Habit>[]> => {
+export const suggestHabitsForGoals = async (goals: Goal[], audience?: string): Promise<Partial<Habit>[]> => {
     if (!process.env.GEMINI_API_KEY) {
         console.error("Gemini API key is not configured.");
         return [
@@ -34,13 +34,14 @@ export const suggestHabitsForGoals = async (goals: Goal[]): Promise<Partial<Habi
     }
 
     const goalDescriptions = goals.map(g => `- ${g.name}: ${g.description}`).join('\n');
+    const target = audience?.trim() || 'the user';
 
     const prompt = `
-Based on the following long-term goals, suggest 3-5 new daily or weekly habits that would help achieve them.
+Based on the following long-term goals, suggest 3-5 new daily or weekly habits that would help ${target} achieve them.
 The habits should be specific, actionable, and small enough to be incorporated into a daily routine.
-Avoid suggesting habits the user might already be doing. Focus on creative or supportive habits.
+Avoid suggesting habits they might already be doing. Focus on creative or supportive habits.
 
-My Goals:
+Goals:
 ${goalDescriptions}
 
 Provide the habits in the specified JSON format.
@@ -104,7 +105,7 @@ const questSchema = {
     required: ["title", "description", "reward", "type"],
 };
 
-export const suggestQuests = async (goals: Goal[], habits: Habit[]): Promise<Omit<Quest, 'id' | 'completed'>[]> => {
+export const suggestQuests = async (goals: Goal[], habits: Habit[], audience?: string): Promise<Omit<Quest, 'id' | 'completed'>[]> => {
     if (!process.env.GEMINI_API_KEY) {
         console.error("Gemini API key is not configured.");
         return [];
@@ -112,17 +113,18 @@ export const suggestQuests = async (goals: Goal[], habits: Habit[]): Promise<Omi
 
     const goalDescriptions = goals.map(g => `- ${g.name}`).join('\n');
     const habitDescriptions = habits.map(h => `- ${h.name}`).join('\n');
+    const target = audience?.trim() || 'the user';
 
     const prompt = `
-Based on the following long-term goals and daily habits, suggest 2-3 unique, one-time "quests".
-A quest should be a specific, short-term challenge that pushes the user slightly beyond their routine to accelerate progress.
+Based on the following long-term goals and daily habits, suggest 2-3 unique, one-time "quests" for ${target}.
+A quest should be a specific, short-term challenge that pushes them slightly beyond their routine to accelerate progress.
 For example, if a goal is 'Learn a new skill', a quest could be 'Complete a 2-hour tutorial on the topic'.
 Avoid suggesting things that are already listed as habits.
 
-My Goals:
+Goals:
 ${goalDescriptions}
 
-My Habits:
+Habits:
 ${habitDescriptions}
 
 Provide the quests in the specified JSON format. The quest 'type' must be 'generic'.


### PR DESCRIPTION
## Summary
- add input on progress tab so users can describe who AI suggestions should target
- pass audience context to Gemini service for habits and quests
- rename Explorer tab to Progress and make it the default view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b9eb1f6ac83309da10cfb07be4214