### PR TITLE
Add basic test setup to enable npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,0 +1,6 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('basic arithmetic works', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- add test script running Node's built-in test runner
- include minimal arithmetic test to exercise setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bcedc62808330b4da148cdd1d1f53