### PR TITLE
Reorder tabs and display level block only on Progress

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -448,7 +448,6 @@ const App: React.FC = () => {
                 />
             )}
             <Header
-                sublimePoints={sublimePoints}
                 activeTab={activeTab}
                 onTabChange={setActiveTab}
             />
@@ -464,8 +463,19 @@ const App: React.FC = () => {
                     />
                 </div>
                 {activeTab === 'progress' && (
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
-                        <Progress avatar={avatar} />
+                    <div className="mb-8">
+                        <div className="flex justify-end mb-4">
+                            <div className="bg-yellow-400/10 border border-yellow-400/50 text-yellow-300 text-base md:text-lg font-semibold px-3 py-1.5 md:px-4 md:py-2 rounded-full flex items-center gap-2">
+                                <span className="text-yellow-500">Lv</span>
+                                <span>{avatar.level}</span>
+                                <span>•</span>
+                                <span>{sublimePoints}</span>
+                                <span className="text-yellow-500">SP</span>
+                            </div>
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                            <Progress avatar={avatar} />
+                        </div>
                     </div>
                 )}
 
@@ -548,15 +558,6 @@ const App: React.FC = () => {
                 className="fixed bottom-0 left-0 right-0 bg-gray-800 border-t border-gray-700 text-gray-400 flex justify-between py-2"
             >
                 <button
-                    onClick={() => setActiveTab('progress')}
-                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'progress' ? 'text-white' : ''}`}
-                    aria-label="Progress"
-                    aria-current={activeTab === 'progress' ? 'page' : undefined}
-                >
-                    <span className="text-xl" aria-hidden="true">📈</span>
-                    <span>Progress</span>
-                </button>
-                <button
                     onClick={() => setActiveTab('habits')}
                     className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'habits' ? 'text-white' : ''}`}
                     aria-label="Habits"
@@ -591,6 +592,15 @@ const App: React.FC = () => {
                 >
                     <span className="text-xl" aria-hidden="true">⚔️</span>
                     <span>Quests</span>
+                </button>
+                <button
+                    onClick={() => setActiveTab('progress')}
+                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'progress' ? 'text-white' : ''}`}
+                    aria-label="Progress"
+                    aria-current={activeTab === 'progress' ? 'page' : undefined}
+                >
+                    <span className="text-xl" aria-hidden="true">📈</span>
+                    <span>Progress</span>
                 </button>
 
             </nav>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,12 +4,11 @@ import { RocketIcon } from './IconComponents';
 type Tab = 'habits' | 'goals' | 'schedule' | 'quests' | 'progress';
 
 interface HeaderProps {
-    sublimePoints: number;
     activeTab: Tab;
     onTabChange: (tab: Tab) => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ sublimePoints, activeTab, onTabChange }) => {
+const Header: React.FC<HeaderProps> = ({ activeTab, onTabChange }) => {
     return (
         <header
             style={{ paddingTop: 'calc(env(safe-area-inset-top, 0) + 0.75rem)' }}
@@ -19,44 +18,38 @@ const Header: React.FC<HeaderProps> = ({ sublimePoints, activeTab, onTabChange }
                 <RocketIcon className="w-7 h-7 md:w-8 md:h-8 text-cyan-400" />
                 <h1 className="text-xl md:text-3xl font-bold font-orbitron text-white">SublimeQuest</h1>
             </div>
-            <div className="flex items-center gap-4">
-                <nav className="hidden md:flex gap-6 text-gray-300">
-                    <button
-                        onClick={() => onTabChange('progress')}
-                        className={`hover:text-cyan-400 transition-colors ${activeTab === 'progress' ? 'text-white' : ''}`}
-                    >
-                        Progress
-                    </button>
-                    <button
-                        onClick={() => onTabChange('habits')}
-                        className={`hover:text-cyan-400 transition-colors ${activeTab === 'habits' ? 'text-white' : ''}`}
-                    >
-                        Habits
-                    </button>
-                    <button
-                        onClick={() => onTabChange('goals')}
-                        className={`hover:text-cyan-400 transition-colors ${activeTab === 'goals' ? 'text-white' : ''}`}
-                    >
-                        Goals
-                    </button>
-                    <button
-                        onClick={() => onTabChange('schedule')}
-                        className={`hover:text-cyan-400 transition-colors ${activeTab === 'schedule' ? 'text-white' : ''}`}
-                    >
-                        Schedule
-                    </button>
-                    <button
-                        onClick={() => onTabChange('quests')}
-                        className={`hover:text-cyan-400 transition-colors ${activeTab === 'quests' ? 'text-white' : ''}`}
-                    >
-                        Quests
-                    </button>
-                </nav>
-                <div className="bg-yellow-400/10 border border-yellow-400/50 text-yellow-300 text-base md:text-lg font-semibold px-3 py-1.5 md:px-4 md:py-2 rounded-full flex items-center gap-2">
-                    <span>{sublimePoints}</span>
-                    <span className="text-yellow-500">SP</span>
-                </div>
-            </div>
+            <nav className="hidden md:flex gap-6 text-gray-300">
+                <button
+                    onClick={() => onTabChange('habits')}
+                    className={`hover:text-cyan-400 transition-colors ${activeTab === 'habits' ? 'text-white' : ''}`}
+                >
+                    Habits
+                </button>
+                <button
+                    onClick={() => onTabChange('goals')}
+                    className={`hover:text-cyan-400 transition-colors ${activeTab === 'goals' ? 'text-white' : ''}`}
+                >
+                    Goals
+                </button>
+                <button
+                    onClick={() => onTabChange('schedule')}
+                    className={`hover:text-cyan-400 transition-colors ${activeTab === 'schedule' ? 'text-white' : ''}`}
+                >
+                    Schedule
+                </button>
+                <button
+                    onClick={() => onTabChange('quests')}
+                    className={`hover:text-cyan-400 transition-colors ${activeTab === 'quests' ? 'text-white' : ''}`}
+                >
+                    Quests
+                </button>
+                <button
+                    onClick={() => onTabChange('progress')}
+                    className={`hover:text-cyan-400 transition-colors ${activeTab === 'progress' ? 'text-white' : ''}`}
+                >
+                    Progress
+                </button>
+            </nav>
         </header>
     );
 };


### PR DESCRIPTION
## Summary
- Reorder navigation so Progress is the fifth tab and remove point display from the global header
- Show level and points badge exclusively on the Progress tab

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bcddbf4748330be1c29c554dbd3d4