### PR TITLE
Polyfill structuredClone for iOS Safari

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,3 +1,4 @@
+import './polyfills';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';

--- a/polyfills.ts
+++ b/polyfills.ts
@@ -1,0 +1,3 @@
+if (typeof globalThis.structuredClone !== 'function') {
+  (globalThis as any).structuredClone = (value: unknown) => JSON.parse(JSON.stringify(value));
+}


### PR DESCRIPTION
## Summary
- provide lightweight structuredClone polyfill for browsers without native support
- initialize polyfills before React render and rely on structuredClone in schedule manager

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bcc260b2083309f59e1a2bd2fe1fd