### PR TITLE
Reduce bottom tab bar height

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -551,52 +551,52 @@ const App: React.FC = () => {
                 )}
             </main>
             <nav
-                style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0) + 0.5rem)' }}
-                className="fixed bottom-0 left-0 right-0 bg-gray-800 border-t border-gray-700 text-gray-400 flex justify-between py-2"
+                style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0) * 0.6)' }}
+                className="fixed bottom-0 left-0 right-0 bg-gray-800 border-t border-gray-700 text-gray-400 flex justify-between py-0"
             >
                 <button
                     onClick={() => setActiveTab('habits')}
-                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'habits' ? 'text-white' : ''}`}
+                    className={`flex-1 flex flex-col items-center gap-0 py-0.5 text-[10px] focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'habits' ? 'text-white' : ''}`}
                     aria-label="Habits"
                     aria-current={activeTab === 'habits' ? 'page' : undefined}
                 >
-                    <span className="text-xl" aria-hidden="true">📋</span>
+                    <span className="text-base" aria-hidden="true">📋</span>
                     <span>Habits</span>
                 </button>
                 <button
                     onClick={() => setActiveTab('goals')}
-                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'goals' ? 'text-white' : ''}`}
+                    className={`flex-1 flex flex-col items-center gap-0 py-0.5 text-[10px] focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'goals' ? 'text-white' : ''}`}
                     aria-label="Goals"
                     aria-current={activeTab === 'goals' ? 'page' : undefined}
                 >
-                    <span className="text-xl" aria-hidden="true">🎯</span>
+                    <span className="text-base" aria-hidden="true">🎯</span>
                     <span>Goals</span>
                 </button>
                 <button
                     onClick={() => setActiveTab('schedule')}
-                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'schedule' ? 'text-white' : ''}`}
+                    className={`flex-1 flex flex-col items-center gap-0 py-0.5 text-[10px] focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'schedule' ? 'text-white' : ''}`}
                     aria-label="Schedule"
                     aria-current={activeTab === 'schedule' ? 'page' : undefined}
                 >
-                    <span className="text-xl" aria-hidden="true">📅</span>
+                    <span className="text-base" aria-hidden="true">📅</span>
                     <span>Schedule</span>
                 </button>
                 <button
                     onClick={() => setActiveTab('quests')}
-                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'quests' ? 'text-white' : ''}`}
+                    className={`flex-1 flex flex-col items-center gap-0 py-0.5 text-[10px] focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'quests' ? 'text-white' : ''}`}
                     aria-label="Quests"
                     aria-current={activeTab === 'quests' ? 'page' : undefined}
                 >
-                    <span className="text-xl" aria-hidden="true">⚔️</span>
+                    <span className="text-base" aria-hidden="true">⚔️</span>
                     <span>Quests</span>
                 </button>
                 <button
                     onClick={() => setActiveTab('progress')}
-                    className={`flex-1 flex flex-col items-center gap-1 py-3 focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'progress' ? 'text-white' : ''}`}
+                    className={`flex-1 flex flex-col items-center gap-0 py-0.5 text-[10px] focus:outline-none focus:ring-2 focus:ring-cyan-500 ${activeTab === 'progress' ? 'text-white' : ''}`}
                     aria-label="Progress"
                     aria-current={activeTab === 'progress' ? 'page' : undefined}
                 >
-                    <span className="text-xl" aria-hidden="true">📈</span>
+                    <span className="text-base" aria-hidden="true">📈</span>
                     <span>Progress</span>
                 </button>
 


### PR DESCRIPTION
## Summary
- Scale safe-area bottom inset and remove gaps to shrink tab bar to roughly 60% height
- Use smaller icons and tighter padding for more compact tabs

## Testing
- `npm test` *(fails: Unknown option `--test`)*

------
https://chatgpt.com/codex/tasks/task_e_689bd64445e08330b1ad129f0a87deab