### PR TITLE
Enable unused checks and remove dead imports

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import type { Avatar, Goal, Habit, Milestone, TimeBlock, Quest } from './types';
+import type { Avatar, Goal, Habit, TimeBlock, Quest } from './types';
 import Header from './components/Header';
 import Progress from './components/Progress';
 import HabitTracker from './components/HabitTracker';

--- a/components/ScheduleManager.tsx
+++ b/components/ScheduleManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import type { TimeBlock, TimeBlockType } from '../types';
 import QuestCard from './QuestCard';
 import { CalendarDaysIcon, PlusIcon, TrashIcon, XMarkIcon, CheckCircleIcon, StarIcon, PencilIcon } from './IconComponents';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,8 @@
       ]
     },
     "allowImportingTsExtensions": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noEmit": true
   }
 }


### PR DESCRIPTION
## Summary
- clean up unused Milestone and useEffect imports
- enable TypeScript's noUnusedLocals and noUnusedParameters options

## Testing
- `npx tsc --noEmit`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bde1786c483309e1ec7f24a0195b9