### PR TITLE
feat: add knowledge base

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import type { Avatar, Goal, Habit, TimeBlock, Quest } from './types';
+import type { Avatar, Goal, Habit, TimeBlock, Quest, KnowledgeItem } from './types';
 import Header from './components/Header';
 import Progress from './components/Progress';
 import HabitTracker from './components/HabitTracker';
@@ -8,6 +8,7 @@ import ScheduleManager from './components/ScheduleManager';
 import QuestTracker from './components/QuestTracker';
 import BreathingExercise from './components/BreathingExercise';
 import { suggestHabitsForGoals, suggestQuests } from './services/geminiService';
+import KnowledgeBase from './components/KnowledgeBase';
 import { useLocalStorage } from './hooks/useLocalStorage';
 
 // --- Helpers ---
@@ -88,6 +89,7 @@ const App: React.FC = () => {
     const [shortTermGoals, setShortTermGoals] = useLocalStorage<Goal[]>('sublime_short_term_goals', INITIAL_SHORT_TERM_GOALS);
     const [timeBlocksByDate, setTimeBlocksByDate] = useLocalStorage<Record<string, TimeBlock[]>>('sublime_schedules', INITIAL_TIME_BLOCKS);
     const [quests, setQuests] = useLocalStorage<Quest[]>('sublime_quests', INITIAL_QUESTS);
+    const [knowledgeBase, setKnowledgeBase] = useLocalStorage<KnowledgeItem[]>('sublime_knowledge_base', []);
     
     const [selectedDate, setSelectedDate] = useState<string>(getTodayString());
     const [isSuggestingHabits, setIsSuggestingHabits] = useState<boolean>(false);
@@ -343,11 +345,15 @@ const App: React.FC = () => {
         setQuests(prev => prev.filter(q => q.id !== questId));
     }, [setQuests]);
 
+    const handleAddKnowledge = useCallback((content: string) => {
+        setKnowledgeBase(prev => [...prev, { id: `kb-${Date.now()}`, content }]);
+    }, [setKnowledgeBase]);
+
     // --- AI Suggestions ---
     const handleSuggestHabits = async () => {
         setIsSuggestingHabits(true);
         try {
-            const suggested = await suggestHabitsForGoals(goals);
+            const suggested = await suggestHabitsForGoals(goals, knowledgeBase.map(k => k.content));
             const newHabits: Habit[] = suggested.map((s, index) => ({
                 id: `suggested-h-${Date.now()}-${index}`,
                 name: s.name || 'New Habit',
@@ -367,7 +373,7 @@ const App: React.FC = () => {
     const handleSuggestQuests = async () => {
         setIsSuggestingQuests(true);
         try {
-            const suggested = await suggestQuests(goals, habits);
+            const suggested = await suggestQuests(goals, habits, knowledgeBase.map(k => k.content));
             const newQuests: Quest[] = suggested.map((q, index) => ({
                 id: `q-${Date.now()}-${index}`,
                 ...q,
@@ -462,6 +468,7 @@ const App: React.FC = () => {
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                             <Progress avatar={avatar} />
+                            <KnowledgeBase items={knowledgeBase} onAdd={handleAddKnowledge} />
                         </div>
                     </div>
                 )}

--- a/components/KnowledgeBase.tsx
+++ b/components/KnowledgeBase.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import QuestCard from './QuestCard';
+import type { KnowledgeItem } from '../types';
+
+interface KnowledgeBaseProps {
+    items: KnowledgeItem[];
+    onAdd: (content: string) => void;
+}
+
+const KnowledgeBase: React.FC<KnowledgeBaseProps> = ({ items, onAdd }) => {
+    const [input, setInput] = useState('');
+
+    const handleAdd = () => {
+        const trimmed = input.trim();
+        if (!trimmed) return;
+        onAdd(trimmed);
+        setInput('');
+    };
+
+    return (
+        <QuestCard className="col-span-1 md:col-span-2 lg:col-span-3">
+            <h2 className="font-orbitron text-xl md:text-2xl text-white mb-4">Knowledge Base</h2>
+            <ul className="text-gray-300 space-y-2 mb-4">
+                {items.map(item => (
+                    <li key={item.id} className="text-sm md:text-base">• {item.content}</li>
+                ))}
+                {items.length === 0 && (
+                    <li className="text-gray-500 text-sm md:text-base">No knowledge added yet.</li>
+                )}
+            </ul>
+            <div className="flex gap-2">
+                <input
+                    type="text"
+                    value={input}
+                    onChange={e => setInput(e.target.value)}
+                    className="flex-grow bg-gray-700 text-white rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                    placeholder="Add knowledge"
+                />
+                <button
+                    onClick={handleAdd}
+                    className="bg-cyan-600 text-white px-4 py-2 rounded hover:bg-cyan-700 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                >
+                    Add
+                </button>
+            </div>
+        </QuestCard>
+    );
+};
+
+export default KnowledgeBase;

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -24,7 +24,7 @@ const habitSchema = {
     required: ["name", "description"],
 };
 
-export const suggestHabitsForGoals = async (goals: Goal[], audience?: string): Promise<Partial<Habit>[]> => {
+export const suggestHabitsForGoals = async (goals: Goal[], knowledgeBase: string[], audience?: string): Promise<Partial<Habit>[]> => {
     if (!process.env.GEMINI_API_KEY) {
         console.error("Gemini API key is not configured.");
         return [
@@ -34,13 +34,15 @@ export const suggestHabitsForGoals = async (goals: Goal[], audience?: string): P
     }
 
     const goalDescriptions = goals.map(g => `- ${g.name}: ${g.description}`).join('\n');
+    const knowledgeDescriptions = knowledgeBase.map(k => `- ${k}`).join('\n');
+    const knowledgeSection = knowledgeDescriptions ? `\nUser Knowledge:\n${knowledgeDescriptions}\n` : '';
     const target = audience?.trim() || 'the user';
 
     const prompt = `
 Based on the following long-term goals, suggest 3-5 new daily or weekly habits that would help ${target} achieve them.
 The habits should be specific, actionable, and small enough to be incorporated into a daily routine.
 Avoid suggesting habits they might already be doing. Focus on creative or supportive habits.
-
+${knowledgeSection}
 Goals:
 ${goalDescriptions}
 
@@ -105,7 +107,7 @@ const questSchema = {
     required: ["title", "description", "reward", "type"],
 };
 
-export const suggestQuests = async (goals: Goal[], habits: Habit[], audience?: string): Promise<Omit<Quest, 'id' | 'completed'>[]> => {
+export const suggestQuests = async (goals: Goal[], habits: Habit[], knowledgeBase: string[], audience?: string): Promise<Omit<Quest, 'id' | 'completed'>[]> => {
     if (!process.env.GEMINI_API_KEY) {
         console.error("Gemini API key is not configured.");
         return [];
@@ -113,6 +115,8 @@ export const suggestQuests = async (goals: Goal[], habits: Habit[], audience?: s
 
     const goalDescriptions = goals.map(g => `- ${g.name}`).join('\n');
     const habitDescriptions = habits.map(h => `- ${h.name}`).join('\n');
+    const knowledgeDescriptions = knowledgeBase.map(k => `- ${k}`).join('\n');
+    const knowledgeSection = knowledgeDescriptions ? `\nUser Knowledge:\n${knowledgeDescriptions}\n` : '';
     const target = audience?.trim() || 'the user';
 
     const prompt = `
@@ -120,7 +124,7 @@ Based on the following long-term goals and daily habits, suggest 2-3 unique, one
 A quest should be a specific, short-term challenge that pushes them slightly beyond their routine to accelerate progress.
 For example, if a goal is 'Learn a new skill', a quest could be 'Complete a 2-hour tutorial on the topic'.
 Avoid suggesting things that are already listed as habits.
-
+${knowledgeSection}
 Goals:
 ${goalDescriptions}
 

--- a/types.ts
+++ b/types.ts
@@ -35,6 +35,11 @@ export interface Quest {
   type: 'breathing' | 'generic';
 }
 
+export interface KnowledgeItem {
+  id: string;
+  content: string;
+}
+
 export type TimeBlockType = 'deep-work' | 'learning' | 'rest' | 'planning' | 'personal';
 
 export interface TimeBlock {


### PR DESCRIPTION
## Summary
- Add knowledge base component for entering user information
- Persist knowledge base and display it on the progress tab
- Include knowledge base context when generating AI habit and quest suggestions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf2b05be48330bfe96906768a8572