### PR TITLE
Add favicon link for app icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <meta name="apple-mobile-web-app-title" content="SublimeQuest">
     <meta name="mobile-web-app-capable" content="yes">
     <link rel="apple-touch-icon" sizes="192x192" href="icons/icon-192x192.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="icons/icon-192x192.png">
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- add favicon link pointing to existing app icon so browsers can display it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c05e1537c833081632ad4d448bdd8