### PR TITLE
feat: improve localStorage handling

### DIFF
--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -1,34 +1,108 @@
 import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 
-function getStorageValue<T>(key: string, defaultValue: T): T {
+interface UseLocalStorageOptions {
+    /**
+     * Maximum age in milliseconds before the stored value expires
+     * and is removed from storage. If not provided, values persist
+     * indefinitely.
+     */
+    maxAge?: number;
+}
+
+interface StorageEntry<T> {
+    value: T;
+    timestamp: number;
+}
+
+// Fallback map when localStorage is unavailable or full.
+const memoryStorage = new Map<string, StorageEntry<any>>();
+
+function getStorageValue<T>(key: string, defaultValue: T, options: UseLocalStorageOptions): T {
     if (typeof window === 'undefined') {
         return defaultValue;
     }
+    const now = Date.now();
     const saved = localStorage.getItem(key);
     if (saved) {
         try {
-            return JSON.parse(saved);
+            const parsed: StorageEntry<T> = JSON.parse(saved);
+            if (options.maxAge && now - parsed.timestamp > options.maxAge) {
+                localStorage.removeItem(key);
+            } else {
+                return parsed.value;
+            }
         } catch (e) {
             console.error("Failed to parse localStorage value", e);
             localStorage.removeItem(key); // Remove corrupted value
-            return defaultValue;
+        }
+    }
+
+    const memoryValue = memoryStorage.get(key);
+    if (memoryValue) {
+        if (options.maxAge && now - memoryValue.timestamp > options.maxAge) {
+            memoryStorage.delete(key);
+        } else {
+            return memoryValue.value;
         }
     }
     return defaultValue;
 }
 
-export function useLocalStorage<T>(key: string, initialValue: T): [T, Dispatch<SetStateAction<T>>] {
+export function useLocalStorage<T>(
+    key: string,
+    initialValue: T,
+    options: UseLocalStorageOptions = {}
+): [T, Dispatch<SetStateAction<T>>] {
     const [value, setValue] = useState<T>(() => {
-        return getStorageValue(key, initialValue);
+        return getStorageValue(key, initialValue, options);
     });
 
     useEffect(() => {
         try {
-            localStorage.setItem(key, JSON.stringify(value));
-        } catch (e) {
-            console.error("Failed to set localStorage value", e);
+            const entry: StorageEntry<T> = { value, timestamp: Date.now() };
+            localStorage.setItem(key, JSON.stringify(entry));
+            memoryStorage.delete(key); // clear fallback on successful write
+        } catch (e: any) {
+            if (e instanceof DOMException && e.name === 'QuotaExceededError') {
+                console.warn('LocalStorage quota exceeded. Attempting cleanup.');
+                try {
+                    // Remove the oldest entry to make room
+                    let oldestKey: string | null = null;
+                    let oldestTimestamp = Infinity;
+                    for (let i = 0; i < localStorage.length; i++) {
+                        const k = localStorage.key(i);
+                        if (!k) continue;
+                        const item = localStorage.getItem(k);
+                        if (!item) continue;
+                        try {
+                            const parsed: StorageEntry<any> = JSON.parse(item);
+                            if (parsed.timestamp < oldestTimestamp) {
+                                oldestTimestamp = parsed.timestamp;
+                                oldestKey = k;
+                            }
+                        } catch {
+                            // If parsing fails, remove corrupted entry
+                            localStorage.removeItem(k);
+                        }
+                    }
+                    if (oldestKey) {
+                        localStorage.removeItem(oldestKey);
+                        const entry: StorageEntry<T> = { value, timestamp: Date.now() };
+                        localStorage.setItem(key, JSON.stringify(entry));
+                        memoryStorage.delete(key);
+                    } else {
+                        memoryStorage.set(key, { value, timestamp: Date.now() });
+                        console.warn('LocalStorage quota exceeded. Using in-memory fallback.');
+                    }
+                } catch {
+                    memoryStorage.set(key, { value, timestamp: Date.now() });
+                    console.warn('LocalStorage quota exceeded. Using in-memory fallback.');
+                }
+            } else {
+                console.error("Failed to set localStorage value", e);
+            }
         }
-    }, [key, value]);
+    }, [key, value, options.maxAge]);
 
     useEffect(() => {
         const handleStorage = (event: StorageEvent) => {
@@ -37,7 +111,8 @@ export function useLocalStorage<T>(key: string, initialValue: T): [T, Dispatch<S
             }
             if (event.newValue) {
                 try {
-                    setValue(JSON.parse(event.newValue));
+                    const parsed: StorageEntry<T> = JSON.parse(event.newValue);
+                    setValue(parsed.value);
                 } catch (e) {
                     console.error("Failed to parse localStorage value", e);
                 }


### PR DESCRIPTION
## Summary
- add optional expiration policy and in-memory fallback for localStorage hook
- handle QuotaExceededError by pruning oldest entries or storing in memory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c072499648330b6f985c6163b107f